### PR TITLE
Fix katakana codes 30f7-30fc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixed
 -----
 
 * Kanwadict: remove entry for 市立 as ichiritsu
+* Issue #59: fix 0x30f7-30fc katakana convertion to be as same as in Hiragana.
 * Appveyor: twine upload credential environment variable name.
 
 

--- a/pykakasi/k2.py
+++ b/pykakasi/k2.py
@@ -77,6 +77,9 @@ class K2 (object):
             if self.isRegion(text[x]) and ord(text[x]) < 0x30f7:
                 Hstr = Hstr + unichr(ord(text[x]) - self._diff)
                 max_len = max_len + 1
+            elif self.isRegion(text[x]):
+                Hstr = Hstr + text[x]
+                max_len = max_len + 1
             else: # pragma: no cover
                 break
         return (Hstr, max_len)

--- a/tests/test_pykakasi_issues.py
+++ b/tests/test_pykakasi_issues.py
@@ -8,6 +8,7 @@ class TestPyKakasiIssues(unittest.TestCase):
 
         TESTS = [
             (59, u"じゃーん", u"じゃーん"),
+            (59, u"ヷヸヹヺ", u"ヷヸヹヺ"),
             (60, u"市立", u"しりつ")
         ]
 

--- a/tests/test_pykakasi_issues.py
+++ b/tests/test_pykakasi_issues.py
@@ -7,6 +7,7 @@ class TestPyKakasiIssues(unittest.TestCase):
     def test_kakasi_issues(self):
 
         TESTS = [
+            (59, u"じゃーん", u"じゃーん"),
             (60, u"市立", u"しりつ")
         ]
 


### PR DESCRIPTION
There is no conversion for 30f7-30fc range when converting to hiragana from katakana.

closed: #59

Signed-off-by: Hiroshi Miura <miurahr@linux.com>