### PR TITLE
Fix convert function omitting the last part of a text

### DIFF
--- a/src/pykakasi/kakasi.py
+++ b/src/pykakasi/kakasi.py
@@ -64,34 +64,23 @@ class kakasi:
         otext = ''
         _result = []
         i = 0
-        while True:
-            if i >= len(text):
-                break
 
+        while i < len(text):
             if self._jconv.isRegion(text[i]):
                 t, ln = self._jconv.convert(text[i:])
                 if ln <= 0:  # pragma: no cover
                     otext = otext + text[i]
                     i += 1
                     _state = False
-                elif (i + ln) < len(text):
-                    if _state:
-                        _result.append(self._iconv(otext + text[i:i + ln], t))
-                        otext = ''
-                    else:
-                        _result.append(self._iconv(otext, otext))
-                        _result.append(self._iconv(text[i:i + ln], t))
-                        otext = ''
-                        _state = True
-                    i = i + ln
                 else:
                     if _state:
                         _result.append(self._iconv(otext + text[i:i + ln], t))
-                    else:  # pragma: no cover
+                    else:
                         _result.append(self._iconv(otext, otext))
                         _result.append(self._iconv(text[i:i + ln], t))
-                    break
-
+                        _state = True
+                    otext = ''
+                    i = i + ln
             else:
                 _state = False
                 otext = otext + text[i]
@@ -101,6 +90,9 @@ class kakasi:
                     _result.append(self._iconv(otext, otext))
                     otext = ''
                     _state = True
+
+        if otext:
+            _result.append(self._iconv(otext, otext))
 
         return _result
 

--- a/src/pykakasi/kakasi.py
+++ b/src/pykakasi/kakasi.py
@@ -113,6 +113,13 @@ class kakasi:
             if l1 > 0:
                 result += t
                 i += l1
+            elif ord(text[i]) in self._LONG_SYMBOL:  # handle chōonpu sound marks
+                # use previous char as a transliteration for kana-dash
+                if len(result) > 0:
+                    result += result[-1]
+                else:
+                    result += '-'
+                i += 1
             else:
                 result += text[i:i + 1]
                 i += 1

--- a/tests/test_pykakasi_structured.py
+++ b/tests/test_pykakasi_structured.py
@@ -11,6 +11,44 @@ import pykakasi
          {'orig': "構成", 'kana': "コウセイ", 'hira': "こうせい",
           'hepburn': 'kousei', 'kunrei': "kousei", 'passport': "kosei"}
      ]),
+    ('好き',
+     [{'orig': '好き', 'hira': 'すき', 'kana': 'スキ', 'hepburn': 'suki', 'kunrei': 'suki', 'passport': 'suki'}]),
+    ('大きい',
+     [{'orig': '大きい', 'hira': 'おおきい', 'kana': 'オオキイ', 'hepburn': 'ookii', 'kunrei': 'ookii', 'passport': 'okii'}]),
+    ('かんたん',
+     [{'orig': 'かんたん', 'hira': 'かんたん', 'kana': 'カンタン', 'hepburn': 'kantan', 'kunrei': 'kantan', 'passport': 'kantan'}]),
+    ('にゃ',
+     [{'orig': 'にゃ', 'hira': 'にゃ', 'kana': 'ニャ', 'hepburn': 'nya', 'kunrei': 'nya', 'passport': 'nya'}]),
+    ('っき',
+     [{'orig': 'っき', 'hira': 'っき', 'kana': 'ッキ', 'hepburn': 'kki', 'kunrei': 'kki', 'passport': 'kki'}]),
+    ('っふぁ',
+     [{'orig': 'っふぁ', 'hira': 'っふぁ', 'kana': 'ッファ', 'hepburn': 'ffa', 'kunrei': 'ffa', 'passport': 'ffa'}]),
+    ('キャ',
+     [{'orig': 'キャ', 'hira': 'キャ', 'kana': 'キャ', 'hepburn': 'キャ', 'kunrei': 'キャ', 'passport': 'キャ'}]),
+    ('キュ',
+     [{'orig': 'キュ', 'hira': 'キュ', 'kana': 'キュ', 'hepburn': 'キュ', 'kunrei': 'キュ', 'passport': 'キュ'}]),
+    ('キョ',
+     [{'orig': 'キョ', 'hira': 'キョ', 'kana': 'キョ', 'hepburn': 'キョ', 'kunrei': 'キョ', 'passport': 'キョ'}]),
+    ('漢字とひらがな交じり文',
+     [
+         {'orig': '漢字', 'hira': 'かんじ', 'kana': 'カンジ', 'hepburn': 'kanji', 'kunrei': 'kanzi', 'passport': 'kanji'},
+         {'orig': 'とひらがな', 'hira': 'とひらがな', 'kana': 'トヒラガナ', 'hepburn': 'tohiragana', 'kunrei': 'tohiragana', 'passport': 'tohiragana'},
+         {'orig': '交じり', 'hira': 'まじり', 'kana': 'マジリ', 'hepburn': 'majiri', 'kunrei': 'maziri', 'passport': 'majiri'},
+         {'orig': '文', 'hira': 'ぶん', 'kana': 'ブン', 'hepburn': 'bun', 'kunrei': 'bun', 'passport': 'bun'}
+     ]),
+    ('Alphabet 123 and 漢字',
+     [
+         {'orig': 'Alphabet 123 and ', 'hira': 'Alphabet 123 and ', 'kana': 'Alphabet 123 and ',
+             'hepburn': 'Alphabet 123 and ', 'kunrei': 'Alphabet 123 and ', 'passport': 'Alphabet 123 and '},
+         {'orig': '漢字', 'hira': 'かんじ', 'kana': 'カンジ', 'hepburn': 'kanji', 'kunrei': 'kanzi', 'passport': 'kanji'}
+     ]),
+    ('日経新聞',
+     [{'orig': '日経新聞', 'hira': 'にっけいしんぶん', 'kana': 'ニッケイシンブン', 'hepburn': 'nikkeishinbun', 'kunrei': 'nikkeisinbun', 'passport': 'nikkeishimbun'}]),
+    ('日本国民は、',
+     [
+         {'orig': '日本国民', 'hira': 'にほんこくみん', 'kana': 'ニホンコクミン', 'hepburn': 'nihonkokumin', 'kunrei': 'nihonkokumin', 'passport': 'nihonkokumin'},
+         {'orig': 'は、', 'hira': 'は、', 'kana': 'ハ、', 'hepburn': 'ha,', 'kunrei': 'ha,', 'passport': 'ha,'}
+     ]),
     ("私がこの子を助けなきゃいけないってことだよね",
      [
          {'orig': "私", 'kana': "ワタシ", 'hira': "わたし", 'hepburn': "watashi", 'kunrei': "watasi", 'passport': "watashi"},

--- a/tests/test_pykakasi_structured.py
+++ b/tests/test_pykakasi_structured.py
@@ -33,6 +33,7 @@ import pykakasi
 def test_kakasi_structured(case, expected):
     kakasi = pykakasi.kakasi()
     result = kakasi.convert(case)
+    assert len(result) == len(expected)
     for i, r in enumerate(result):
         assert r['orig'] == expected[i]['orig']
         assert r['hira'] == expected[i]['hira']


### PR DESCRIPTION
Fix for #99 . I have refactored the *convert* function in the *kakasi* class to append the last result of a text conversion.