### PR TITLE
fix: clear buffer after flush in PUA-drop / else branches

### DIFF
--- a/src/pykakasi/kakasi.py
+++ b/src/pykakasi/kakasi.py
@@ -125,12 +125,16 @@ class Kakasi:
                 # flush first
                 if len(original_text) > 0:
                     _result.append(self._iconv.convert(original_text, kana_text))
+                    original_text = ""
+                    kana_text = ""
                 i += 1
                 action_flag = _ACTION.DO_NOTHING
             else:
                 # flush first
                 if len(original_text) > 0:
                     _result.append(self._iconv.convert(original_text, kana_text))
+                    original_text = ""
+                    kana_text = ""
                 _result.append(self._iconv.convert(text[i], ""))
                 i += 1
                 action_flag = _ACTION.DO_NOTHING

--- a/tests/test_pykakasi_structured.py
+++ b/tests/test_pykakasi_structured.py
@@ -668,3 +668,34 @@ def test_aozora():
     assert result[9]['kana'] == 'サレテ'
     assert result[10]['kana'] == 'イル'
     assert result[11]['kana'] == '。'
+
+
+def test_issue_161_halfwidth_punctuation_no_duplication():
+    """Codeberg #161 - characters in the 0xF000-0xFFFD "PUA" branch (which
+    also catches halfwidth Japanese punctuation in the 0xFF61-0xFF65 range)
+    used to leave the pending-text buffer un-cleared. The buffer was then
+    emitted a second time by the final-word cleanup, producing duplicated
+    tokens whenever input ended with - or contained - these characters.
+
+    Halfwidth period ｡ (U+FF61), comma ､ (U+FF64), and katakana
+    middle dot ･ (U+FF65) are common in Japanese broadcast subtitles,
+    so this affected real-world corpora.
+    """
+    kks = pykakasi.kakasi()
+
+    # Trailing halfwidth period - previously produced ["はい", "はい"].
+    r = kks.convert("はい｡")
+    assert [x["orig"] for x in r] == ["はい"]
+
+    # Halfwidth period mid-string - previously produced
+    # ["はい", "はいうん"] because the buffer was not cleared.
+    r = kks.convert("はい｡うん")
+    assert [x["orig"] for x in r] == ["はい", "うん"]
+
+    # Halfwidth comma (U+FF64) - same family.
+    r = kks.convert("はい､うん")
+    assert [x["orig"] for x in r] == ["はい", "うん"]
+
+    # Halfwidth katakana middle dot (U+FF65) as a name separator.
+    r = kks.convert("かまいたち･山内")
+    assert [x["orig"] for x in r] == ["かまいたち", "山内"]


### PR DESCRIPTION
The PUA-drop branch and the fallback else branch flushed original_text to the result but didn't reset it, so the end-of-convert() "last word" cleanup re-emitted the same tokens.

Hits halfwidth Japanese punctuation ｡ ､ ･ (U+FF61, FF64, FF65), which falls into the 0xF000-0xFFFD "PUA" check. e.g. はい｡ produced ['はい', 'はい']; かまいたち･山内 produced ['かまいたち', 'かまいたち', '山内'].

Fixes #161 (on codeberg).